### PR TITLE
Speed up arithmetic operations involving Proxy subclasses

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -3,3 +3,4 @@ Authors
 =======
 
 * Ionel Cristian Mărieș - https://blog.ionelmc.ro
+* Erik M. Bray - https://iguananaut.net

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+1.2.3 (unreleased)
+------------------
+
+* Speed up arithmetic operations involving ``Proxy`` subclasses.
+
 1.2.2 (2016-04-14)
 ------------------
 

--- a/src/lazy_object_proxy/cext.c
+++ b/src/lazy_object_proxy/cext.c
@@ -9,8 +9,7 @@
 #endif
 
 #define Proxy__WRAPPED_REPLACE_OR_RETURN_NULL(object) \
-    if (PyObject_TypeCheck(object, &Proxy_Type) || \
-            PyObject_IsInstance(object, (PyObject *)&Proxy_Type)) { \
+    if (PyObject_TypeCheck(object, &Proxy_Type)) { \
         object = Proxy__ensure_wrapped((ProxyObject *)object); \
         if (!object) return NULL; \
     }

--- a/src/lazy_object_proxy/cext.c
+++ b/src/lazy_object_proxy/cext.c
@@ -9,7 +9,8 @@
 #endif
 
 #define Proxy__WRAPPED_REPLACE_OR_RETURN_NULL(object) \
-    if (PyObject_IsInstance(object, (PyObject *)&Proxy_Type)) { \
+    if (PyObject_TypeCheck(object, &Proxy_Type) || \
+            PyObject_IsInstance(object, (PyObject *)&Proxy_Type)) { \
         object = Proxy__ensure_wrapped((ProxyObject *)object); \
         if (!object) return NULL; \
     }


### PR DESCRIPTION
Arithmetic operations on subclasses of `Proxy` (specifically the C implementation) are slower (roughly three times) due to inexact match in the `PyObject_Instance` call in `Proxy__WRAPPED_REPLACE_OR_RETURN_NULL`.  For simple C-level type compatibility checking `PyObject_TypeCheck` is much faster.  In fact the `PyObject_IsInstance` is probably superfluous with this but I left it anyways.

### Before:

```
In [1]: from lazy_object_proxy import Proxy

In [2]: a = Proxy(int)

In [3]: str(a)
Out[3]: '0'

In [4]: %timeit -n 1000000 -r 100 a + a
1000000 loops, best of 100: 61.1 ns per loop

In [5]: class MyProxy(Proxy): pass

In [6]: b = MyProxy(int)

In [7]: str(b)
Out[7]: '0'

In [8]: %timeit -n 1000000 -r 100 b + b
1000000 loops, best of 100: 171 ns per loop
```

### After:

```
In [1]: from lazy_object_proxy import Proxy

In [2]: a = Proxy(int)

In [3]: str(a)
Out[3]: '0'

In [4]: %timeit -n 1000000 -r 100 a + a
1000000 loops, best of 100: 57.4 ns per loop

In [5]: class MyProxy(Proxy): pass

In [6]: b = MyProxy(int)

In [7]: str(b)
Out[7]: '0'

In [8]: %timeit -n 1000000 -r 100 b + b
1000000 loops, best of 100: 62.1 ns per loop
```