### PR TITLE
setuptools 45.0 has not support py2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools>=30.3.0", "wheel", "setuptools_scm>=3.3.1"]
+requires = ["setuptools==43.0.0", "wheel", "setuptools_scm>=3.3.1"]


### PR DESCRIPTION
Fix https://github.com/ionelmc/python-lazy-object-proxy/issues/33