### PR TITLE
Stop trying to use cPickle, removed from python3

### DIFF
--- a/tests/test_lazy_object_proxy.py
+++ b/tests/test_lazy_object_proxy.py
@@ -1708,7 +1708,7 @@ def test_set_wrapped_regular(lop):
     assert obj + 1 == 2
 
 
-@pytest.fixture(params=["pickle", "cPickle"])
+@pytest.fixture(params=["pickle", ])
 def pickler(request):
     return pytest.importorskip(request.param)
 


### PR DESCRIPTION
cPickle has been removed in python3, and since lazy-object-proxy now only supports python3, we can remove it.

The effect of keeping it there is 300+ tests being skipped, confusing the test suite output