### PR TITLE
tests:async: Fix Python3.12 deprecation warning

### DIFF
--- a/tests/test_async_py3.py
+++ b/tests/test_async_py3.py
@@ -249,7 +249,7 @@ def test_func_10(lop):
     aw = coro.__await__()
     next(aw)
     with pytest.raises(ZeroDivisionError):
-        aw.throw(ZeroDivisionError, None, None)
+        aw.throw(ZeroDivisionError)
     assert N == 102
 
 


### PR DESCRIPTION
Using the old signature to `throw()`, Python3.12 will complain with the following DeprecationWarning:

FAILED tests/test_async_py3.py::test_func_10[normal-cext] - DeprecationWarning: the (type, exc, tb) signature of throw() is deprecated, use the single-arg signature instead.

See: https://docs.python.org/3/reference/expressions.html#generator.throw